### PR TITLE
feat: add timetable constants

### DIFF
--- a/campus_python/api/v1/__init__.py
+++ b/campus_python/api/v1/__init__.py
@@ -9,6 +9,7 @@ from . import (
     assignments,
     circles,
     submissions,
+    timetable,
 )
 
 class ApiRoot(ResourceRoot):
@@ -51,3 +52,13 @@ class ApiRoot(ResourceRoot):
                 root=self
             )
         return self._submissions
+
+    @property
+    def timetable(self) -> timetable.Timetable:
+        """Get the timetable resource."""
+        if not self._timetable:
+            self._timetable = timetable.Timetable(
+                self._json_client,
+                root=self
+            )
+        return self._timetable

--- a/campus_python/api/v1/timetable.py
+++ b/campus_python/api/v1/timetable.py
@@ -1,0 +1,55 @@
+"""campus_python.api.v1.timetable
+
+Campus API timetable resource (v1).
+"""
+
+import campus.model
+
+from ...interface import Resource, ResourceCollection
+
+TIMESLOTS = [
+    "0730",
+    "0800",
+    "0830",
+    "0900",
+    "0930",
+    "1000",
+    "1030",
+    "1100",
+    "1130",
+    "1200",
+    "1230",
+    "1300",
+    "1330",
+    "1400",
+    "1430",
+    "1500",
+    "1530",
+    "1600",
+    "1630",
+    "1700",
+    "1730",
+    "1800",
+    "1830",
+    "1900",
+]
+WEEKDAYS = [
+    "Mon A",
+    "Tue A",
+    "Wed A",
+    "Thu A",
+    "Fri A",
+    "Mon B",
+    "Tue B",
+    "Wed B",
+    "Thu B",
+    "Fri B",
+]
+
+
+class Timetable(ResourceCollection):
+    """Campus API Timetable resource."""
+    path = "timetable"
+    # hardcoded enums
+    timeslots = TIMESLOTS
+    weekdays = WEEKDAYS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "campus-api-python"
-version = "0.1.45"
+version = "0.1.46"
 description = "Campus API for Python projects"
 authors = ["NYJC Computing <nyjc.computing@nyjc.edu.sg>"]
 


### PR DESCRIPTION
This PR adds `campus.api.timetable.timeslots` and `campus.api.timetable.weekdays` constants.