### PR TITLE
Fix client collection paths to match server URL patterns

### DIFF
--- a/campus_python/api/v1/assignments.py
+++ b/campus_python/api/v1/assignments.py
@@ -10,7 +10,7 @@ from ...interface import Resource, ResourceCollection
 
 class Assignments(ResourceCollection):
     """Campus API Assignments resource."""
-    path = "assignments"
+    path = "assignments/"
 
     def __getitem__(self, assignment_id: str) -> "Assignments.Assignment":
         """Get a specific assignment resource by ID."""

--- a/campus_python/api/v1/circles.py
+++ b/campus_python/api/v1/circles.py
@@ -10,7 +10,7 @@ from ...interface import Resource, ResourceCollection
 
 class Circles(ResourceCollection):
     """Campus API Circles resource."""
-    path = "circles"
+    path = "circles/"
 
     def __getitem__(self, circle_id: str) -> "Circles.Circle":
         """Get a specific circle resource by ID."""


### PR DESCRIPTION
## Summary
Update client collection paths to include trailing slashes to match server-side URL patterns.

## Changes
- **campus_python.api.v1.circles**: Update collection path from `"circles"` to `"circles/"`
- **campus_python.api.v1.assignments**: Update collection path from `"assignments"` to `"assignments/"`

## Details
This fix ensures client URLs match the server's trailing slash convention where collection endpoints always have trailing slashes. This prevents redirect issues and maintains consistency with the documented URL schema.

## Related
- Matches server-side URL pattern fixes in campus repository PR: nyjc-computing/campus#573
- Follows trailing slash convention documented in campus repository docs/campus-api-schema.md

## Testing
- Client modules import successfully
- Path updates verified to match server route patterns
- No breaking changes to client API

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>